### PR TITLE
chore: fixing incorrect link and updating docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ A plugin for deploying open-source artifacts to Maven via the Sonatype Central p
 1. Add the following to your `project/plugins.sbt` file (or equivalent):
 
 ```sbt
-addSbtPlugin("com.lumidion"   % "sbt-sonatype-central"  % "0.1.0")
-addSbtPlugin("com.github.sbt" % "sbt-pgp"               % "2.2.1")
+addSbtPlugin("com.lumidion"   % "sbt-sonatype-central"  % "0.1.0") //For deploying your lib to Sonatype Central
+addSbtPlugin("com.github.sbt" % "sbt-pgp"               % "2.2.1") //For signing the lib before it is deployed
+addSbtPlugin("com.github.sbt" % "sbt-git"               % "2.0.1") //For adding source control information to your package.
 ```
 
 2. Make sure that your version is not a snapshot (Sonatype Central does not support publishing snapshot versions).

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ publishTo := sonatypeCentralPublishToBundle.value
 inThisBuild {
   Seq(
     scalaVersion := versions.scala,
-    homepage     := Some(url("https://github.com/lumidion/sonatype-central-client")),
+    homepage     := Some(url("https://github.com/lumidion/sbt-sonatype-central")),
     licenses     := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     developers := List(
       Developer(


### PR DESCRIPTION
This PR enhances the documentation around required (or recommended) plugins in the `Getting Started` section. It also fixes an incorrect homepage link in the package metadata.